### PR TITLE
Introduced action navigation designators to cram_highlevel

### DIFF
--- a/cram_plan_library/src/achieve-loc.lisp
+++ b/cram_plan_library/src/achieve-loc.lisp
@@ -38,7 +38,8 @@
               (distance-to-drive ?loc))
     (achieve `(looking-at :forward))
     (achieve '(arms-parked)))
-  (pm-execute :navigation ?loc))
+  (with-designators ((navigation-action (action `((type navigation) (goal ,?loc)))))
+    (pm-execute :navigation navigation-action)))
 
 (def-goal (achieve (loc ?obj ?loc))
   (ros-info (achieve plan-lib) "(achieve (loc ?obj ?loc)")

--- a/cram_plan_library/src/package.lisp
+++ b/cram_plan_library/src/package.lisp
@@ -68,5 +68,5 @@
   (:desig-properties #:to #:see #:obj #:of #:reach :type #:trajectory #:pose #:open #:side
                      #:grasp #:lift #:carry :reach #:location #:at #:parked #:pose #:close
                      #:gripper #:follow #:pick-up #:put-down #:height #:orientation #:in
-                     #:obstacle #:cluster #:execute #:action))
+                     #:obstacle #:cluster #:execute #:action #:goal #:navigation))
 


### PR DESCRIPTION
Modified (def-goal (achieve (loc Robot ?loc)) ...) to use an action navigation designator instead of a pure location designator in order to achieve a certain location.
